### PR TITLE
Implement the blobs.get port

### DIFF
--- a/di/inject_adapters.go
+++ b/di/inject_adapters.go
@@ -73,6 +73,7 @@ func newTxRepositoriesFactory(local identity.Public, logger logging.Logger, hmac
 var blobsAdaptersSet = wire.NewSet(
 	newFilesystemStorage,
 	wire.Bind(new(blobReplication.BlobStorage), new(*blobs.FilesystemStorage)),
+	wire.Bind(new(queries.BlobStorage), new(*blobs.FilesystemStorage)),
 )
 
 func newFilesystemStorage(logger logging.Logger, config Config) (*blobs.FilesystemStorage, error) {

--- a/di/inject_application.go
+++ b/di/inject_application.go
@@ -41,4 +41,7 @@ var queriesSet = wire.NewSet(
 	queries.NewReceiveLogHandler,
 	queries.NewStatusHandler,
 	queries.NewPublishedMessagesHandler,
+
+	queries.NewGetBlobHandler,
+	wire.Bind(new(portsrpc.GetBlobQueryHandler), new(*queries.GetBlobHandler)),
 )

--- a/di/wire.go
+++ b/di/wire.go
@@ -89,6 +89,7 @@ type TestQueries struct {
 	MessagePubSub     *mocks.MessagePubSubMock
 	MessageRepository *mocks.MessageRepositoryMock
 	PeerManager       *mocks.PeerManagerMock
+	BlobStorage       *mocks.BlobStorageMock
 }
 
 func BuildTestQueries() (TestQueries, error) {
@@ -104,6 +105,9 @@ func BuildTestQueries() (TestQueries, error) {
 
 		identity.NewPrivate,
 		privateIdentityToPublicIdentity,
+
+		mocks.NewBlobStorageMock,
+		wire.Bind(new(queries.BlobStorage), new(*mocks.BlobStorageMock)),
 
 		wire.Struct(new(TestQueries), "*"),
 	)

--- a/internal/ptr.go
+++ b/internal/ptr.go
@@ -1,0 +1,5 @@
+package internal
+
+func Ptr[T any](o T) *T {
+	return &o
+}

--- a/service/adapters/blobs/storage.go
+++ b/service/adapters/blobs/storage.go
@@ -84,9 +84,18 @@ func (f FilesystemStorage) Store(id refs.Blob, r io.Reader) error {
 	return nil
 }
 
-func (f FilesystemStorage) GetBlob(id refs.Blob) (io.ReadCloser, error) {
+func (f FilesystemStorage) Get(id refs.Blob) (io.ReadCloser, error) {
 	name := f.pathStorage(id)
 	return os.Open(name)
+}
+
+func (f FilesystemStorage) Size(id refs.Blob) (blobs.Size, error) {
+	name := f.pathStorage(id)
+	fi, err := os.Stat(name)
+	if err != nil {
+		return blobs.Size{}, errors.Wrap(err, "stat failed")
+	}
+	return blobs.NewSize(fi.Size())
 }
 
 func (f FilesystemStorage) createStorage() error {

--- a/service/adapters/blobs/storage.go
+++ b/service/adapters/blobs/storage.go
@@ -75,13 +75,18 @@ func (f FilesystemStorage) Store(id refs.Blob, r io.Reader) error {
 	}
 
 	oldName := tmpFile.Name()
-	newName := f.pathStorage(hexRef)
+	newName := f.pathStorage(id)
 
 	if err := os.Rename(oldName, newName); err != nil {
 		return errors.Wrap(err, "failed to rename the file")
 	}
 
 	return nil
+}
+
+func (f FilesystemStorage) GetBlob(id refs.Blob) (io.ReadCloser, error) {
+	name := f.pathStorage(id)
+	return os.Open(name)
 }
 
 func (f FilesystemStorage) createStorage() error {
@@ -100,8 +105,9 @@ func (f FilesystemStorage) dirStorage() string {
 	return path.Join(f.path, "storage")
 }
 
-func (f FilesystemStorage) pathStorage(name string) string {
-	return path.Join(f.dirStorage(), name)
+func (f FilesystemStorage) pathStorage(id refs.Blob) string {
+	hexRef := hex.EncodeToString(id.Bytes())
+	return path.Join(f.dirStorage(), hexRef)
 }
 
 func (f FilesystemStorage) removeTemporaryFiles() error {

--- a/service/adapters/blobs/storage_test.go
+++ b/service/adapters/blobs/storage_test.go
@@ -20,13 +20,22 @@ func TestStorage(t *testing.T) {
 	storage, err := blobs.NewFilesystemStorage(directory, logger)
 	require.NoError(t, err)
 
-	id, r := newFakeBlob(t)
+	id, r, data := newFakeBlob(t)
 
 	err = storage.Store(id, r)
 	require.NoError(t, err)
+
+	rc, err := storage.GetBlob(id)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	readData, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	require.Equal(t, data, readData)
 }
 
-func newFakeBlob(t *testing.T) (refs.Blob, io.Reader) {
+func newFakeBlob(t *testing.T) (refs.Blob, io.Reader, []byte) {
 	buf := &bytes.Buffer{}
 
 	h := blobsdomain.NewHasher()
@@ -39,5 +48,5 @@ func newFakeBlob(t *testing.T) (refs.Blob, io.Reader) {
 	id, err := h.SumRef()
 	require.NoError(t, err)
 
-	return id, buf
+	return id, buf, data
 }

--- a/service/adapters/blobs/storage_test.go
+++ b/service/adapters/blobs/storage_test.go
@@ -25,7 +25,7 @@ func TestStorage(t *testing.T) {
 	err = storage.Store(id, r)
 	require.NoError(t, err)
 
-	rc, err := storage.GetBlob(id)
+	rc, err := storage.Get(id)
 	require.NoError(t, err)
 	defer rc.Close()
 

--- a/service/adapters/mocks/blob_storage_mock.go
+++ b/service/adapters/mocks/blob_storage_mock.go
@@ -1,0 +1,34 @@
+package mocks
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/service/domain/refs"
+)
+
+type BlobStorageMock struct {
+	blobs map[string][]byte
+}
+
+func NewBlobStorageMock() *BlobStorageMock {
+	return &BlobStorageMock{
+		blobs: make(map[string][]byte),
+	}
+}
+
+func (b BlobStorageMock) GetBlob(id refs.Blob) (io.ReadCloser, error) {
+	data, ok := b.blobs[id.String()]
+	if !ok {
+		return nil, errors.New("blob not found")
+	}
+	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+}
+
+func (b BlobStorageMock) MockBlob(id refs.Blob, data []byte) {
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	b.blobs[id.String()] = cpy
+}

--- a/service/adapters/mocks/blob_storage_mock.go
+++ b/service/adapters/mocks/blob_storage_mock.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/refs"
 )
 
@@ -19,12 +20,20 @@ func NewBlobStorageMock() *BlobStorageMock {
 	}
 }
 
-func (b BlobStorageMock) GetBlob(id refs.Blob) (io.ReadCloser, error) {
+func (b BlobStorageMock) Get(id refs.Blob) (io.ReadCloser, error) {
 	data, ok := b.blobs[id.String()]
 	if !ok {
 		return nil, errors.New("blob not found")
 	}
 	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+}
+
+func (b BlobStorageMock) Size(id refs.Blob) (blobs.Size, error) {
+	data, ok := b.blobs[id.String()]
+	if !ok {
+		return blobs.Size{}, errors.New("blob not found")
+	}
+	return blobs.NewSize(int64(len(data)))
 }
 
 func (b BlobStorageMock) MockBlob(id refs.Blob, data []byte) {

--- a/service/app/application.go
+++ b/service/app/application.go
@@ -28,4 +28,5 @@ type Queries struct {
 	ReceiveLog          *queries.ReceiveLogHandler
 	Status              *queries.StatusHandler
 	PublishedMessages   *queries.PublishedMessagesHandler
+	GetBlob             *queries.GetBlobHandler
 }

--- a/service/app/queries/create_history_stream_test.go
+++ b/service/app/queries/create_history_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/di"
 	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/service/adapters/mocks"
 	"github.com/planetary-social/go-ssb/service/app/queries"
 	"github.com/planetary-social/go-ssb/service/domain/feeds/message"
@@ -226,7 +227,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:  "repository_should_enforce_sequence_by_itself",
-			Seq:   sequencePointer(2),
+			Seq:   internal.Ptr(message.MustNewSequence(2)),
 			Limit: nil,
 			Repository: []message.Message{
 				msg1,
@@ -242,7 +243,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:  "earlier_messages_from_pubsub_should_be_omitted_if_repository_returned_something",
-			Seq:   sequencePointer(1),
+			Seq:   internal.Ptr(message.MustNewSequence(1)),
 			Limit: nil,
 			Repository: []message.Message{
 				msg2,
@@ -259,7 +260,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:       "earlier_messages_from_pubsub_should_be_omitted_if_repository_returned_nothing",
-			Seq:        sequencePointer(1),
+			Seq:        internal.Ptr(message.MustNewSequence(1)),
 			Limit:      nil,
 			Repository: nil,
 			PubSub: []message.Message{
@@ -274,7 +275,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:  "repository_should_enforce_limit_by_itself",
-			Limit: intPointer(2),
+			Limit: internal.Ptr(2),
 			Repository: []message.Message{
 				msg1,
 				msg2,
@@ -289,7 +290,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:  "if_repository_exhausted_the_limit_then_live_should_do_nothing",
-			Limit: intPointer(2),
+			Limit: internal.Ptr(2),
 			Repository: []message.Message{
 				msg1,
 				msg2,
@@ -304,7 +305,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:  "repository_should_count_towards_the_limit",
-			Limit: intPointer(2),
+			Limit: internal.Ptr(2),
 			Repository: []message.Message{
 				msg1,
 			},
@@ -319,7 +320,7 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:       "live_should_keep_track_of_the_limit",
-			Limit:      intPointer(2),
+			Limit:      internal.Ptr(2),
 			Repository: nil,
 			PubSub: []message.Message{
 				msg1,
@@ -390,13 +391,4 @@ func TestCreateHistoryStream(t *testing.T) {
 			require.Equal(t, testCase.ExpectedMessages, receivedMessages)
 		})
 	}
-}
-
-func sequencePointer(s int) *message.Sequence {
-	seq := message.MustNewSequence(s)
-	return &seq
-}
-
-func intPointer(s int) *int {
-	return &s
 }

--- a/service/app/queries/get_blob.go
+++ b/service/app/queries/get_blob.go
@@ -3,15 +3,26 @@ package queries
 import (
 	"io"
 
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/refs"
 )
 
 type BlobStorage interface {
-	GetBlob(id refs.Blob) (io.ReadCloser, error)
+	Get(id refs.Blob) (io.ReadCloser, error)
+	Size(id refs.Blob) (blobs.Size, error)
 }
 
 type GetBlob struct {
 	Id refs.Blob
+
+	// Size is the expected size of the blob in bytes. If the blob is not
+	// exactly this size then an error is returned.
+	Size *blobs.Size
+
+	// Max is the Maximum size of the blob in bytes. If the blob is larger then
+	// an error is returned.
+	Max *blobs.Size
 }
 
 type GetBlobHandler struct {
@@ -25,5 +36,24 @@ func NewGetBlobHandler(storage BlobStorage) (*GetBlobHandler, error) {
 }
 
 func (h *GetBlobHandler) Handle(query GetBlob) (io.ReadCloser, error) {
-	return h.storage.GetBlob(query.Id)
+	if query.Size != nil || query.Max != nil {
+		blobSize, err := h.storage.Size(query.Id)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get the blob size")
+		}
+
+		if query.Size != nil {
+			if blobSize != *query.Size {
+				return nil, errors.New("blob size doesn't match the provided size")
+			}
+		}
+
+		if query.Max != nil {
+			if blobSize.Above(*query.Max) {
+				return nil, errors.New("blob is larger than the provided max size")
+			}
+		}
+	}
+
+	return h.storage.Get(query.Id)
 }

--- a/service/app/queries/get_blob.go
+++ b/service/app/queries/get_blob.go
@@ -1,0 +1,29 @@
+package queries
+
+import (
+	"io"
+
+	"github.com/planetary-social/go-ssb/service/domain/refs"
+)
+
+type BlobStorage interface {
+	GetBlob(id refs.Blob) (io.ReadCloser, error)
+}
+
+type GetBlob struct {
+	Id refs.Blob
+}
+
+type GetBlobHandler struct {
+	storage BlobStorage
+}
+
+func NewGetBlobHandler(storage BlobStorage) (*GetBlobHandler, error) {
+	return &GetBlobHandler{
+		storage: storage,
+	}, nil
+}
+
+func (h *GetBlobHandler) Handle(query GetBlob) (io.ReadCloser, error) {
+	return h.storage.GetBlob(query.Id)
+}

--- a/service/app/queries/get_blob_test.go
+++ b/service/app/queries/get_blob_test.go
@@ -1,0 +1,27 @@
+package queries_test
+
+import (
+	"testing"
+
+	"github.com/planetary-social/go-ssb/di"
+	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/service/app/queries"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBlob(t *testing.T) {
+	q, err := di.BuildTestQueries()
+	require.NoError(t, err)
+
+	id := fixtures.SomeRefBlob()
+
+	q.BlobStorage.MockBlob(id, fixtures.SomeBytes())
+
+	query := queries.GetBlob{
+		Id: id,
+	}
+
+	rc, err := q.Queries.GetBlob.Handle(query)
+	require.NoError(t, err)
+	require.NotNil(t, rc)
+}

--- a/service/app/queries/get_blob_test.go
+++ b/service/app/queries/get_blob_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/di"
 	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/service/app/queries"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/stretchr/testify/require"
@@ -33,7 +34,7 @@ func TestGetBlob(t *testing.T) {
 			Name: "id_and_correct_size",
 			Query: queries.GetBlob{
 				Id:   id,
-				Size: sizePtr(blobs.MustNewSize(int64(len(data)))),
+				Size: internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 				Max:  nil,
 			},
 			ExpectedError: nil,
@@ -42,7 +43,7 @@ func TestGetBlob(t *testing.T) {
 			Name: "id_and_incorrect_size",
 			Query: queries.GetBlob{
 				Id:   id,
-				Size: sizePtr(blobs.MustNewSize(10)),
+				Size: internal.Ptr(blobs.MustNewSize(10)),
 				Max:  nil,
 			},
 			ExpectedError: errors.New("blob size doesn't match the provided size"),
@@ -52,7 +53,7 @@ func TestGetBlob(t *testing.T) {
 			Query: queries.GetBlob{
 				Id:   id,
 				Size: nil,
-				Max:  sizePtr(blobs.MustNewSize(int64(len(data)) + 1)),
+				Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)) + 1)),
 			},
 			ExpectedError: nil,
 		},
@@ -61,7 +62,7 @@ func TestGetBlob(t *testing.T) {
 			Query: queries.GetBlob{
 				Id:   id,
 				Size: nil,
-				Max:  sizePtr(blobs.MustNewSize(int64(len(data)))),
+				Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 			},
 			ExpectedError: nil,
 		},
@@ -70,7 +71,7 @@ func TestGetBlob(t *testing.T) {
 			Query: queries.GetBlob{
 				Id:   id,
 				Size: nil,
-				Max:  sizePtr(blobs.MustNewSize(int64(len(data)) - 1)),
+				Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)) - 1)),
 			},
 			ExpectedError: errors.New("blob is larger than the provided max size"),
 		},
@@ -78,8 +79,8 @@ func TestGetBlob(t *testing.T) {
 			Name: "size_wins_over_max",
 			Query: queries.GetBlob{
 				Id:   id,
-				Size: sizePtr(blobs.MustNewSize(1)),
-				Max:  sizePtr(blobs.MustNewSize(1)),
+				Size: internal.Ptr(blobs.MustNewSize(1)),
+				Max:  internal.Ptr(blobs.MustNewSize(1)),
 			},
 			ExpectedError: errors.New("blob size doesn't match the provided size"),
 		},
@@ -102,8 +103,4 @@ func TestGetBlob(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sizePtr(s blobs.Size) *blobs.Size {
-	return &s
 }

--- a/service/domain/blobs/replication/downloader.go
+++ b/service/domain/blobs/replication/downloader.go
@@ -46,7 +46,7 @@ func (d *BlobsGetDownloader) OnHasReceived(ctx context.Context, peer transport.P
 }
 
 func (d *BlobsGetDownloader) download(ctx context.Context, peer transport.Peer, blob refs.Blob) error {
-	arguments, err := messages.NewBlobsGetArguments(blob)
+	arguments, err := messages.NewBlobsGetArguments(blob, nil, nil)
 	if err != nil {
 		return errors.Wrap(err, "could not create a request")
 	}

--- a/service/domain/blobs/size.go
+++ b/service/domain/blobs/size.go
@@ -32,6 +32,10 @@ func (s Size) InBytes() int64 {
 	return s.sizeInBytes
 }
 
-func (s Size) Above(size Size) bool {
-	return s.sizeInBytes > size.sizeInBytes
+func (s Size) Above(other Size) bool {
+	return s.sizeInBytes > other.sizeInBytes
+}
+
+func (s Size) IsZero() bool {
+	return s == Size{}
 }

--- a/service/domain/blobs/size_or_want_distance_test.go
+++ b/service/domain/blobs/size_or_want_distance_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +27,7 @@ func TestSizeOrWantDistance(t *testing.T) {
 		{
 			Name:                 "positive_number_is_the_size",
 			Value:                1,
-			ExpectedSize:         sizePointer(blobs.MustNewSize(1)),
+			ExpectedSize:         internal.Ptr(blobs.MustNewSize(1)),
 			ExpectedWantDistance: nil,
 			ExpectedError:        nil,
 		},
@@ -34,7 +35,7 @@ func TestSizeOrWantDistance(t *testing.T) {
 			Name:                 "negative_number_is_the_want_distance",
 			Value:                -1,
 			ExpectedSize:         nil,
-			ExpectedWantDistance: wantDistancePointer(blobs.MustNewWantDistance(1)),
+			ExpectedWantDistance: internal.Ptr(blobs.MustNewWantDistance(1)),
 			ExpectedError:        nil,
 		},
 	}
@@ -63,12 +64,4 @@ func TestSizeOrWantDistance(t *testing.T) {
 			}
 		})
 	}
-}
-
-func sizePointer(size blobs.Size) *blobs.Size {
-	return &size
-}
-
-func wantDistancePointer(distance blobs.WantDistance) *blobs.WantDistance {
-	return &distance
 }

--- a/service/domain/messages/blobs_get.go
+++ b/service/domain/messages/blobs_get.go
@@ -29,13 +29,13 @@ func NewBlobsGet(arguments BlobsGetArguments) (*rpc.Request, error) {
 }
 
 type BlobsGetArguments struct {
-	id        refs.Blob
+	hash      refs.Blob
 	size, max *blobs.Size
 }
 
-func NewBlobsGetArguments(id refs.Blob, size, max *blobs.Size) (BlobsGetArguments, error) {
-	if id.IsZero() {
-		return BlobsGetArguments{}, errors.New("zero value of id")
+func NewBlobsGetArguments(hash refs.Blob, size, max *blobs.Size) (BlobsGetArguments, error) {
+	if hash.IsZero() {
+		return BlobsGetArguments{}, errors.New("zero value of hash")
 	}
 
 	if size != nil && size.IsZero() {
@@ -47,7 +47,7 @@ func NewBlobsGetArguments(id refs.Blob, size, max *blobs.Size) (BlobsGetArgument
 	}
 
 	return BlobsGetArguments{
-		id:   id,
+		hash: hash,
 		size: size,
 		max:  max,
 	}, nil
@@ -122,7 +122,7 @@ func newBlobsGetArgumentsFromBytesObject(b []byte) (BlobsGetArguments, error) {
 func (a BlobsGetArguments) MarshalJSON() ([]byte, error) {
 	if a.size == nil && a.max == nil {
 		args := []string{
-			a.id.String(),
+			a.hash.String(),
 		}
 
 		return json.Marshal(args)
@@ -130,7 +130,7 @@ func (a BlobsGetArguments) MarshalJSON() ([]byte, error) {
 
 	args := []blobsGetArgumentsTransport{
 		{
-			Hash: a.id.String(),
+			Hash: a.hash.String(),
 		},
 	}
 
@@ -147,8 +147,8 @@ func (a BlobsGetArguments) MarshalJSON() ([]byte, error) {
 	return json.Marshal(args)
 }
 
-func (a BlobsGetArguments) Id() refs.Blob {
-	return a.id
+func (a BlobsGetArguments) Hash() refs.Blob {
+	return a.hash
 }
 
 func (a BlobsGetArguments) Size() (blobs.Size, bool) {

--- a/service/domain/messages/blobs_get_test.go
+++ b/service/domain/messages/blobs_get_test.go
@@ -1,14 +1,97 @@
-package messages
+package messages_test
 
 import (
 	"testing"
 
+	"github.com/planetary-social/go-ssb/service/domain/blobs"
+	"github.com/planetary-social/go-ssb/service/domain/messages"
+	"github.com/planetary-social/go-ssb/service/domain/refs"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewBlobsGetArgumentsFromBytes(t *testing.T) {
-	args, err := NewBlobsGetArgumentsFromBytes([]byte(`["&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"]`))
+func TestNewBlobsMarshal(t *testing.T) {
+	testCases := []struct {
+		Name string
+
+		Hash refs.Blob
+		Size *blobs.Size
+		Max  *blobs.Size
+
+		ExpectedJSON string
+	}{
+		{
+			Name: "only_hash",
+
+			Hash: refs.MustNewBlob("&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"),
+			Size: nil,
+			Max:  nil,
+
+			ExpectedJSON: `["\u0026uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"]`,
+		},
+		{
+			Name: "hash_and_size",
+
+			Hash: refs.MustNewBlob("&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"),
+			Size: sizePtr(blobs.MustNewSize(123)),
+			Max:  nil,
+
+			ExpectedJSON: `[{"hash":"\u0026uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256","size":123}]`,
+		},
+		{
+			Name: "hash_and_max",
+
+			Hash: refs.MustNewBlob("&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"),
+			Size: nil,
+			Max:  sizePtr(blobs.MustNewSize(123)),
+
+			ExpectedJSON: `[{"hash":"\u0026uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256","max":123}]`,
+		},
+		{
+			Name: "hash_and_size_and_max",
+
+			Hash: refs.MustNewBlob("&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"),
+			Size: sizePtr(blobs.MustNewSize(123)),
+			Max:  sizePtr(blobs.MustNewSize(456)),
+
+			ExpectedJSON: `[{"hash":"\u0026uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256","size":123,"max":456}]`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			args, err := messages.NewBlobsGetArguments(testCase.Hash, testCase.Size, testCase.Max)
+			require.NoError(t, err)
+
+			j, err := args.MarshalJSON()
+			require.NoError(t, err)
+
+			require.Equal(t, testCase.ExpectedJSON, string(j))
+		})
+	}
+}
+
+func TestNewBlobsGetArgumentsFromBytesString(t *testing.T) {
+	args, err := messages.NewBlobsGetArgumentsFromBytes([]byte(`["&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"]`))
 	require.NoError(t, err)
 
 	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Id().String())
+}
+
+func TestNewBlobsGetArgumentsFromBytesObject(t *testing.T) {
+	args, err := messages.NewBlobsGetArgumentsFromBytes([]byte(`[{"hash": "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", "size": 161699, "max": 200000}]`))
+	require.NoError(t, err)
+
+	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Id().String())
+
+	size, ok := args.Size()
+	require.True(t, ok)
+	require.Equal(t, blobs.MustNewSize(161699), size)
+
+	max, ok := args.Max()
+	require.True(t, ok)
+	require.Equal(t, blobs.MustNewSize(200000), max)
+}
+
+func sizePtr(s blobs.Size) *blobs.Size {
+	return &s
 }

--- a/service/domain/messages/blobs_get_test.go
+++ b/service/domain/messages/blobs_get_test.go
@@ -74,14 +74,14 @@ func TestNewBlobsGetArgumentsFromBytesString(t *testing.T) {
 	args, err := messages.NewBlobsGetArgumentsFromBytes([]byte(`["&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256"]`))
 	require.NoError(t, err)
 
-	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Id().String())
+	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Hash().String())
 }
 
 func TestNewBlobsGetArgumentsFromBytesObject(t *testing.T) {
 	args, err := messages.NewBlobsGetArgumentsFromBytes([]byte(`[{"hash": "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", "size": 161699, "max": 200000}]`))
 	require.NoError(t, err)
 
-	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Id().String())
+	require.Equal(t, "&uaGieSQDJcHfUp6hjIcIq55GoZh4Ug7tNmgaohoxrpw=.sha256", args.Hash().String())
 
 	size, ok := args.Size()
 	require.True(t, ok)

--- a/service/domain/replication/manager_test.go
+++ b/service/domain/replication/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/logging"
 	"github.com/planetary-social/go-ssb/service/domain/feeds/message"
 	"github.com/planetary-social/go-ssb/service/domain/graph"
@@ -165,26 +166,26 @@ func TestManager_SequenceIsDeterminedBasedOnStorageStateAndMessageBufferState(t 
 		{
 			Name:              "storage_empty",
 			SequenceInStorage: nil,
-			SequenceInBuffer:  sequencePointer(message.MustNewSequence(10)),
-			ExpectedSequence:  sequencePointer(message.MustNewSequence(10)),
+			SequenceInBuffer:  internal.Ptr(message.MustNewSequence(10)),
+			ExpectedSequence:  internal.Ptr(message.MustNewSequence(10)),
 		},
 		{
 			Name:              "buffer_empty",
-			SequenceInStorage: sequencePointer(message.MustNewSequence(10)),
+			SequenceInStorage: internal.Ptr(message.MustNewSequence(10)),
 			SequenceInBuffer:  nil,
-			ExpectedSequence:  sequencePointer(message.MustNewSequence(10)),
+			ExpectedSequence:  internal.Ptr(message.MustNewSequence(10)),
 		},
 		{
 			Name:              "buffer_larger",
-			SequenceInStorage: sequencePointer(message.MustNewSequence(10)),
-			SequenceInBuffer:  sequencePointer(message.MustNewSequence(20)),
-			ExpectedSequence:  sequencePointer(message.MustNewSequence(20)),
+			SequenceInStorage: internal.Ptr(message.MustNewSequence(10)),
+			SequenceInBuffer:  internal.Ptr(message.MustNewSequence(20)),
+			ExpectedSequence:  internal.Ptr(message.MustNewSequence(20)),
 		},
 		{
 			Name:              "storage_larger",
-			SequenceInStorage: sequencePointer(message.MustNewSequence(20)),
-			SequenceInBuffer:  sequencePointer(message.MustNewSequence(10)),
-			ExpectedSequence:  sequencePointer(message.MustNewSequence(20)),
+			SequenceInStorage: internal.Ptr(message.MustNewSequence(20)),
+			SequenceInBuffer:  internal.Ptr(message.MustNewSequence(10)),
+			ExpectedSequence:  internal.Ptr(message.MustNewSequence(20)),
 		},
 	}
 
@@ -285,8 +286,4 @@ func (m messageBufferMock) SetSequence(feed refs.Feed, sequence message.Sequence
 func (m messageBufferMock) Sequence(feed refs.Feed) (message.Sequence, bool) {
 	seq, ok := m.sequences[feed.String()]
 	return seq, ok
-}
-
-func sequencePointer(sequence message.Sequence) *message.Sequence {
-	return &sequence
 }

--- a/service/ports/rpc/handler_blobs_get.go
+++ b/service/ports/rpc/handler_blobs_get.go
@@ -1,24 +1,37 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"io"
 
 	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/service/app/queries"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
 	"github.com/planetary-social/go-ssb/service/domain/transport/rpc"
 	"github.com/planetary-social/go-ssb/service/domain/transport/rpc/mux"
 )
 
-type BlobStorage interface {
-	Get() (io.ReadCloser, error)
+const (
+	// MaxBlobChunkSizeInBytes specifies the max size of one response payload
+	// when sending blobs. Larger blobs are broken into several payloads. This
+	// is done to give other pieces of code some wire time and avoid blocking
+	// the connection completely when sending the blob.
+	MaxBlobChunkSizeInBytes = 100 * 1000
+)
+
+type GetBlobQueryHandler interface {
+	Handle(query queries.GetBlob) (io.ReadCloser, error)
 }
 
 type HandlerBlobsGet struct {
+	handler GetBlobQueryHandler
 }
 
-func NewHandlerBlobsGet() *HandlerBlobsGet {
-	return &HandlerBlobsGet{}
+func NewHandlerBlobsGet(handler GetBlobQueryHandler) *HandlerBlobsGet {
+	return &HandlerBlobsGet{
+		handler: handler,
+	}
 }
 
 func (h HandlerBlobsGet) Procedure() rpc.Procedure {
@@ -26,10 +39,37 @@ func (h HandlerBlobsGet) Procedure() rpc.Procedure {
 }
 
 func (h HandlerBlobsGet) Handle(ctx context.Context, w mux.ResponseWriter, req *rpc.Request) error {
-	_, err := messages.NewBlobsGetArgumentsFromBytes(req.Arguments())
+	args, err := messages.NewBlobsGetArgumentsFromBytes(req.Arguments())
 	if err != nil {
 		return errors.Wrap(err, "invalid arguments")
 	}
 
-	return errors.New("not implemented")
+	query := queries.GetBlob{
+		Id: args.Id(),
+	}
+
+	rc, err := h.handler.Handle(query)
+	if err != nil {
+		return errors.Wrap(err, "error executing the query")
+	}
+	defer rc.Close()
+
+	buf := &bytes.Buffer{}
+
+	for {
+		n, err := io.Copy(buf, io.LimitReader(rc, MaxBlobChunkSizeInBytes))
+		if err != nil {
+			return errors.Wrap(err, "failed to copy into buffer")
+		}
+
+		if n == 0 {
+			return nil
+		}
+
+		if err := w.WriteMessage(buf.Bytes()); err != nil {
+			return errors.Wrap(err, "failed to write the message")
+		}
+
+		buf.Reset()
+	}
 }

--- a/service/ports/rpc/handler_blobs_get.go
+++ b/service/ports/rpc/handler_blobs_get.go
@@ -48,6 +48,14 @@ func (h HandlerBlobsGet) Handle(ctx context.Context, w mux.ResponseWriter, req *
 		Id: args.Id(),
 	}
 
+	if size, ok := args.Size(); ok {
+		query.Size = &size
+	}
+
+	if max, ok := args.Max(); ok {
+		query.Max = &max
+	}
+
 	rc, err := h.handler.Handle(query)
 	if err != nil {
 		return errors.Wrap(err, "error executing the query")

--- a/service/ports/rpc/handler_blobs_get.go
+++ b/service/ports/rpc/handler_blobs_get.go
@@ -45,7 +45,7 @@ func (h HandlerBlobsGet) Handle(ctx context.Context, w mux.ResponseWriter, req *
 	}
 
 	query := queries.GetBlob{
-		Id: args.Id(),
+		Id: args.Hash(),
 	}
 
 	if size, ok := args.Size(); ok {

--- a/service/ports/rpc/handler_blobs_get_test.go
+++ b/service/ports/rpc/handler_blobs_get_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/service/app/queries"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
@@ -47,12 +48,12 @@ func TestArgumentsArePassedToQuery(t *testing.T) {
 			Name: "hash_and_size",
 
 			Hash: hash,
-			Size: sizePtr(blobs.MustNewSize(int64(len(data)))),
+			Size: internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 			Max:  nil,
 
 			ExpectedQuery: queries.GetBlob{
 				Id:   hash,
-				Size: sizePtr(blobs.MustNewSize(int64(len(data)))),
+				Size: internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 				Max:  nil,
 			},
 		},
@@ -61,25 +62,25 @@ func TestArgumentsArePassedToQuery(t *testing.T) {
 
 			Hash: hash,
 			Size: nil,
-			Max:  sizePtr(blobs.MustNewSize(int64(len(data)))),
+			Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 
 			ExpectedQuery: queries.GetBlob{
 				Id:   hash,
 				Size: nil,
-				Max:  sizePtr(blobs.MustNewSize(int64(len(data)))),
+				Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 			},
 		},
 		{
 			Name: "hash_and_size_and_max",
 
 			Hash: hash,
-			Size: sizePtr(blobs.MustNewSize(int64(len(data)))),
-			Max:  sizePtr(blobs.MustNewSize(int64(len(data)))),
+			Size: internal.Ptr(blobs.MustNewSize(int64(len(data)))),
+			Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 
 			ExpectedQuery: queries.GetBlob{
 				Id:   hash,
-				Size: sizePtr(blobs.MustNewSize(int64(len(data)))),
-				Max:  sizePtr(blobs.MustNewSize(int64(len(data)))),
+				Size: internal.Ptr(blobs.MustNewSize(int64(len(data)))),
+				Max:  internal.Ptr(blobs.MustNewSize(int64(len(data)))),
 			},
 		},
 	}
@@ -246,8 +247,4 @@ func (r *readCloserTrackingCloses) Read(p []byte) (n int, err error) {
 func (r *readCloserTrackingCloses) Close() error {
 	r.onClose(r)
 	return nil
-}
-
-func sizePtr(s blobs.Size) *blobs.Size {
-	return &s
 }

--- a/service/ports/rpc/handler_blobs_get_test.go
+++ b/service/ports/rpc/handler_blobs_get_test.go
@@ -1,0 +1,154 @@
+package rpc_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/service/app/queries"
+	"github.com/planetary-social/go-ssb/service/domain/messages"
+	"github.com/planetary-social/go-ssb/service/domain/refs"
+	transportrpc "github.com/planetary-social/go-ssb/service/domain/transport/rpc"
+	"github.com/planetary-social/go-ssb/service/ports/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIfHandlerReturnsErrorNoMessagesAreSent(t *testing.T) {
+	queryHandler := newGetBlobQueryHandlerMock()
+	h := rpc.NewHandlerBlobsGet(queryHandler)
+
+	ctx := fixtures.TestContext(t)
+	rw := NewMockResponseWriter()
+	req := createBlobsGetRequest(t, fixtures.SomeRefBlob())
+
+	err := h.Handle(ctx, rw, req)
+	require.Error(t, err)
+
+	require.Empty(t, rw.WrittenMessages)
+}
+
+func TestSmallBlobIsWrittenToResponseWriter(t *testing.T) {
+	queryHandler := newGetBlobQueryHandlerMock()
+	h := rpc.NewHandlerBlobsGet(queryHandler)
+
+	id := fixtures.SomeRefBlob()
+	queryHandler.MockBlob(id, []byte("test"))
+
+	ctx := fixtures.TestContext(t)
+	rw := NewMockResponseWriter()
+	req := createBlobsGetRequest(t, id)
+
+	err := h.Handle(ctx, rw, req)
+	require.NoError(t, err)
+
+	require.Len(t, rw.WrittenMessages, 1)
+	require.Equal(t, []byte("test"), rw.WrittenMessages[0])
+
+	queryHandler.RequireThereAreNoOpenReadClosers(t)
+}
+
+func TestLargeBlobIsWrittenToResponseWriter(t *testing.T) {
+	queryHandler := newGetBlobQueryHandlerMock()
+	h := rpc.NewHandlerBlobsGet(queryHandler)
+
+	payloadInFirstMessage := []byte(strings.Repeat("a", rpc.MaxBlobChunkSizeInBytes))
+	payloadInSecondMessage := []byte(strings.Repeat("b", rpc.MaxBlobChunkSizeInBytes))
+	payloadInThirdMessage := []byte("something that doesn't fill up the message completely")
+
+	var payload []byte
+	payload = append(payload, payloadInFirstMessage...)
+	payload = append(payload, payloadInSecondMessage...)
+	payload = append(payload, payloadInThirdMessage...)
+
+	id := fixtures.SomeRefBlob()
+	queryHandler.MockBlob(id, payload)
+
+	ctx := fixtures.TestContext(t)
+	rw := NewMockResponseWriter()
+	req := createBlobsGetRequest(t, id)
+
+	err := h.Handle(ctx, rw, req)
+	require.NoError(t, err)
+
+	require.Len(t, rw.WrittenMessages, 3)
+	require.Equal(t, payloadInFirstMessage, rw.WrittenMessages[0])
+	require.Equal(t, payloadInSecondMessage, rw.WrittenMessages[1])
+	require.Equal(t, payloadInThirdMessage, rw.WrittenMessages[2])
+
+	queryHandler.RequireThereAreNoOpenReadClosers(t)
+}
+
+type getBlobQueryHandlerMock struct {
+	blobs           map[string][]byte
+	openReadClosers map[*readCloserTrackingCloses]struct{}
+}
+
+func newGetBlobQueryHandlerMock() *getBlobQueryHandlerMock {
+	return &getBlobQueryHandlerMock{
+		blobs:           make(map[string][]byte),
+		openReadClosers: make(map[*readCloserTrackingCloses]struct{}),
+	}
+}
+
+func (h getBlobQueryHandlerMock) Handle(query queries.GetBlob) (io.ReadCloser, error) {
+	data, ok := h.blobs[query.Id.String()]
+	if !ok {
+		return nil, errors.New("blob not found")
+	}
+	return newReadCloserTrackingCloses(bytes.NewBuffer(data), h.openReadClosers), nil
+}
+
+func (h getBlobQueryHandlerMock) MockBlob(id refs.Blob, data []byte) {
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	h.blobs[id.String()] = cpy
+}
+
+func (h getBlobQueryHandlerMock) RequireThereAreNoOpenReadClosers(t *testing.T) {
+	require.Empty(t, h.openReadClosers)
+}
+
+func createBlobsGetRequest(t *testing.T, id refs.Blob) *transportrpc.Request {
+	args, err := messages.NewBlobsGetArguments(
+		id,
+	)
+	require.NoError(t, err)
+
+	argsBytes, err := args.MarshalJSON()
+	require.NoError(t, err)
+
+	req, err := transportrpc.NewRequest(
+		fixtures.SomeProcedureName(),
+		fixtures.SomeProcedureType(),
+		argsBytes,
+	)
+	require.NoError(t, err)
+
+	return req
+}
+
+type readCloserTrackingCloses struct {
+	reader io.Reader
+	m      map[*readCloserTrackingCloses]struct{}
+}
+
+func newReadCloserTrackingCloses(reader io.Reader, m map[*readCloserTrackingCloses]struct{}) *readCloserTrackingCloses {
+	rc := &readCloserTrackingCloses{
+		reader: reader,
+		m:      m,
+	}
+	m[rc] = struct{}{}
+	return rc
+}
+
+func (r *readCloserTrackingCloses) Read(p []byte) (n int, err error) {
+	return r.reader.Read(p)
+}
+
+func (r *readCloserTrackingCloses) Close() error {
+	delete(r.m, r)
+	return nil
+}

--- a/service/ports/rpc/handler_create_history_stream_test.go
+++ b/service/ports/rpc/handler_create_history_stream_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/internal"
 	"github.com/planetary-social/go-ssb/service/app/queries"
 	"github.com/planetary-social/go-ssb/service/domain/feeds/message"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
@@ -27,12 +28,12 @@ func TestCreateHistoryStream(t *testing.T) {
 		},
 		{
 			Name:         "true",
-			Keys:         boolPointer(true),
+			Keys:         internal.Ptr(true),
 			ContainsKeys: true,
 		},
 		{
 			Name:         "false",
-			Keys:         boolPointer(false),
+			Keys:         internal.Ptr(false),
 			ContainsKeys: false,
 		},
 	}
@@ -127,8 +128,4 @@ func (m MockCreateHistoryStreamQueryHandler) Handle(ctx context.Context, query q
 	}()
 
 	return ch
-}
-
-func boolPointer(v bool) *bool {
-	return &v
 }

--- a/service/ports/rpc/handler_create_history_stream_test.go
+++ b/service/ports/rpc/handler_create_history_stream_test.go
@@ -97,7 +97,9 @@ func NewMockResponseWriter() *MockResponseWriter {
 }
 
 func (m *MockResponseWriter) WriteMessage(body []byte) error {
-	m.WrittenMessages = append(m.WrittenMessages, body)
+	cpy := make([]byte, len(body))
+	copy(cpy, body)
+	m.WrittenMessages = append(m.WrittenMessages, cpy)
 	return nil
 }
 


### PR DESCRIPTION
Blobs are sent in chunks to avoid using up too much wire time in one
handler.