### PR TITLE
Reply to "wants" messages with "has" messages

### DIFF
--- a/cmd/ssb-test/main.go
+++ b/cmd/ssb-test/main.go
@@ -19,8 +19,6 @@ import (
 	"github.com/planetary-social/go-ssb/service/domain/feeds/formats"
 	"github.com/planetary-social/go-ssb/service/domain/identity"
 	"github.com/planetary-social/go-ssb/service/domain/invites"
-	"github.com/planetary-social/go-ssb/service/domain/network"
-	"github.com/planetary-social/go-ssb/service/domain/refs"
 	"github.com/planetary-social/go-ssb/service/domain/transport/boxstream"
 	"github.com/sirupsen/logrus"
 )
@@ -33,27 +31,27 @@ func main() {
 }
 
 var (
-	myPatchwork        = refs.MustNewIdentity("@qFtLJ6P5Eh9vKxnj7Rsh8SkE6B6Z36DVLP7ZOKNeQ/Y=.ed25519")
-	myPatchworkConnect = commands.Connect{
-		Remote:  myPatchwork.Identity(),
-		Address: network.NewAddress("127.0.0.1:8008"),
-	}
+//myPatchwork        = refs.MustNewIdentity("@qFtLJ6P5Eh9vKxnj7Rsh8SkE6B6Z36DVLP7ZOKNeQ/Y=.ed25519")
+//myPatchworkConnect = commands.Connect{
+//	Remote:  myPatchwork.Identity(),
+//	Address: network.NewAddress("127.0.0.1:8008"),
+//}
 
-	//localGoSSB        = refs.MustNewIdentity("@ln1Bdt8lEy4/F/szWlFVAIAIdCBKmzH2MNEVad8BWus=.ed25519")
-	//localGoSSBConnect = commands.Connect{
-	//	Remote:  localGoSSB.Identity(),
-	//	Address: network.NewAddress("127.0.0.1:8008"),
-	//}
+//localGoSSB        = refs.MustNewIdentity("@ln1Bdt8lEy4/F/szWlFVAIAIdCBKmzH2MNEVad8BWus=.ed25519")
+//localGoSSBConnect = commands.Connect{
+//	Remote:  localGoSSB.Identity(),
+//	Address: network.NewAddress("127.0.0.1:8008"),
+//}
 
-	mainnetPub = invites.MustNewInviteFromString("one.planetary.pub:8008:@CIlwTOK+m6v1hT2zUVOCJvvZq7KE/65ErN6yA2yrURY=.ed25519~KVvak/aZeQJQUrn1imLIvwU+EVTkCzGW8TJWTmK8lOk=")
+//mainnetPub = invites.MustNewInviteFromString("one.planetary.pub:8008:@CIlwTOK+m6v1hT2zUVOCJvvZq7KE/65ErN6yA2yrURY=.ed25519~KVvak/aZeQJQUrn1imLIvwU+EVTkCzGW8TJWTmK8lOk=")
 
-	//soapdog = refs.MustNewIdentity("@qv10rF4IsmxRZb7g5ekJ33EakYBpdrmV/vtP1ij5BS4=.ed25519")
+//soapdog = refs.MustNewIdentity("@qv10rF4IsmxRZb7g5ekJ33EakYBpdrmV/vtP1ij5BS4=.ed25519")
 
-	//pub         = refs.MustNewIdentity("@CIlwTOK+m6v1hT2zUVOCJvvZq7KE/65ErN6yA2yrURY=.ed25519")
-	//hubConnect = commands2.Connect{
-	//	Remote:  pub.Identity(),
-	//	Address: network2.NewAddress("one.planetary.pub:8008"),
-	//}
+//pub         = refs.MustNewIdentity("@CIlwTOK+m6v1hT2zUVOCJvvZq7KE/65ErN6yA2yrURY=.ed25519")
+//hubConnect = commands2.Connect{
+//	Remote:  pub.Identity(),
+//	Address: network2.NewAddress("one.planetary.pub:8008"),
+//}
 )
 
 var (

--- a/di/inject_adapters.go
+++ b/di/inject_adapters.go
@@ -74,6 +74,7 @@ var blobsAdaptersSet = wire.NewSet(
 	newFilesystemStorage,
 	wire.Bind(new(blobReplication.BlobStorage), new(*blobs.FilesystemStorage)),
 	wire.Bind(new(queries.BlobStorage), new(*blobs.FilesystemStorage)),
+	wire.Bind(new(blobReplication.BlobSizeRepository), new(*blobs.FilesystemStorage)),
 )
 
 func newFilesystemStorage(logger logging.Logger, config Config) (*blobs.FilesystemStorage, error) {

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -248,7 +248,7 @@ func BuildService(contextContext context.Context, private identity.Private, conf
 		return Service{}, err
 	}
 	blobsGetDownloader := replication2.NewBlobsGetDownloader(filesystemStorage, logger)
-	replicationManager := replication2.NewManager(readWantListRepository, blobsGetDownloader, logger)
+	replicationManager := replication2.NewManager(readWantListRepository, filesystemStorage, blobsGetDownloader, logger)
 	replicator := replication2.NewReplicator(replicationManager)
 	peerManager := domain.NewPeerManager(contextContext, peerManagerConfig, gossipReplicator, replicator, dialer, logger)
 	connectHandler := commands.NewConnectHandler(peerManager, logger)

--- a/service/adapters/blobs/storage.go
+++ b/service/adapters/blobs/storage.go
@@ -13,6 +13,7 @@ import (
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/logging"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
+	"github.com/planetary-social/go-ssb/service/domain/blobs/replication"
 	"github.com/planetary-social/go-ssb/service/domain/refs"
 )
 
@@ -93,6 +94,9 @@ func (f FilesystemStorage) Size(id refs.Blob) (blobs.Size, error) {
 	name := f.pathStorage(id)
 	fi, err := os.Stat(name)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return blobs.Size{}, replication.ErrBlobNotFound
+		}
 		return blobs.Size{}, errors.Wrap(err, "stat failed")
 	}
 	return blobs.NewSize(fi.Size())

--- a/service/adapters/blobs/storage_test.go
+++ b/service/adapters/blobs/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/planetary-social/go-ssb/logging"
 	"github.com/planetary-social/go-ssb/service/adapters/blobs"
 	blobsdomain "github.com/planetary-social/go-ssb/service/domain/blobs"
+	blobReplication "github.com/planetary-social/go-ssb/service/domain/blobs/replication"
 	"github.com/planetary-social/go-ssb/service/domain/refs"
 	"github.com/stretchr/testify/require"
 )
@@ -25,6 +26,10 @@ func TestStorage(t *testing.T) {
 	err = storage.Store(id, r)
 	require.NoError(t, err)
 
+	size, err := storage.Size(id)
+	require.NoError(t, err)
+	require.Equal(t, len(data), size.InBytes())
+
 	rc, err := storage.Get(id)
 	require.NoError(t, err)
 	defer rc.Close()
@@ -33,6 +38,17 @@ func TestStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, data, readData)
+}
+
+func TestSizeReturnsBlobNotFound(t *testing.T) {
+	directory := fixtures.Directory(t)
+	logger := logging.NewDevNullLogger()
+
+	storage, err := blobs.NewFilesystemStorage(directory, logger)
+	require.NoError(t, err)
+
+	_, err = storage.Size(fixtures.SomeRefBlob())
+	require.ErrorIs(t, err, blobReplication.ErrBlobNotFound)
 }
 
 func newFakeBlob(t *testing.T) (refs.Blob, io.Reader, []byte) {

--- a/service/adapters/blobs/storage_test.go
+++ b/service/adapters/blobs/storage_test.go
@@ -28,7 +28,7 @@ func TestStorage(t *testing.T) {
 
 	size, err := storage.Size(id)
 	require.NoError(t, err)
-	require.Equal(t, len(data), size.InBytes())
+	require.EqualValues(t, len(data), size.InBytes())
 
 	rc, err := storage.Get(id)
 	require.NoError(t, err)

--- a/service/domain/blobs/replication/common.go
+++ b/service/domain/blobs/replication/common.go
@@ -1,0 +1,29 @@
+package replication
+
+import (
+	"context"
+	"io"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/service/domain/blobs"
+	"github.com/planetary-social/go-ssb/service/domain/refs"
+	"github.com/planetary-social/go-ssb/service/domain/transport"
+)
+
+type WantListStorage interface {
+	GetWantList() (blobs.WantList, error)
+}
+
+type Downloader interface {
+	OnHasReceived(ctx context.Context, peer transport.Peer, blob refs.Blob, size blobs.Size)
+}
+
+var ErrBlobNotFound = errors.New("blob not found")
+
+type BlobStorage interface {
+	Store(id refs.Blob, r io.Reader) error
+
+	// Size returns the size of the blob. If the blob is not found it returns
+	// ErrBlobNotFound.
+	Size(id refs.Blob) (blobs.Size, error)
+}

--- a/service/domain/blobs/replication/common.go
+++ b/service/domain/blobs/replication/common.go
@@ -22,7 +22,9 @@ var ErrBlobNotFound = errors.New("blob not found")
 
 type BlobStorage interface {
 	Store(id refs.Blob, r io.Reader) error
+}
 
+type BlobSizeRepository interface {
 	// Size returns the size of the blob. If the blob is not found it returns
 	// ErrBlobNotFound.
 	Size(id refs.Blob) (blobs.Size, error)

--- a/service/domain/blobs/replication/downloader.go
+++ b/service/domain/blobs/replication/downloader.go
@@ -14,15 +14,6 @@ import (
 	"github.com/planetary-social/go-ssb/service/domain/transport/rpc"
 )
 
-var ErrBlobNotFound = errors.New("blob not found")
-
-type BlobStorage interface {
-	Store(id refs.Blob, r io.Reader) error
-
-	// Size returns the size of the blob. If the blob is not found it returns ErrBlobNotFound.
-	Size(id refs.Blob) (blobs.Size, error)
-}
-
 type BlobsGetDownloader struct {
 	storage BlobStorage
 	logger  logging.Logger

--- a/service/domain/blobs/replication/downloader.go
+++ b/service/domain/blobs/replication/downloader.go
@@ -14,8 +14,13 @@ import (
 	"github.com/planetary-social/go-ssb/service/domain/transport/rpc"
 )
 
+var ErrBlobNotFound = errors.New("blob not found")
+
 type BlobStorage interface {
 	Store(id refs.Blob, r io.Reader) error
+
+	// Size returns the size of the blob. If the blob is not found it returns ErrBlobNotFound.
+	Size(id refs.Blob) (blobs.Size, error)
 }
 
 type BlobsGetDownloader struct {

--- a/service/domain/blobs/replication/manager.go
+++ b/service/domain/blobs/replication/manager.go
@@ -17,6 +17,7 @@ type Manager struct {
 	downloader      Downloader
 	logger          logging.Logger
 
+	// todo cleanup processes
 	processes map[rpc.ConnectionId]*WantsProcess
 	lock      sync.Mutex // guards processes
 }

--- a/service/domain/blobs/replication/manager.go
+++ b/service/domain/blobs/replication/manager.go
@@ -3,170 +3,76 @@ package replication
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/logging"
-	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
-	"github.com/planetary-social/go-ssb/service/domain/refs"
 	"github.com/planetary-social/go-ssb/service/domain/transport"
 	"github.com/planetary-social/go-ssb/service/domain/transport/rpc"
 )
 
-type WantListStorage interface {
-	GetWantList() (blobs.WantList, error)
-}
-
-type Downloader interface {
-	OnHasReceived(ctx context.Context, peer transport.Peer, blob refs.Blob, size blobs.Size)
-}
-
 type Manager struct {
-	storage           WantListStorage
-	downloader        Downloader
-	connectionStreams *connectionStreams
-	logger            logging.Logger
+	wantListStorage WantListStorage
+	blobStorage     BlobStorage
+	downloader      Downloader
+	logger          logging.Logger
+
+	processes map[rpc.ConnectionId]*WantsProcess
+	lock      sync.Mutex // guards processes
 }
 
-func NewManager(storage WantListStorage, downloader Downloader, logger logging.Logger) *Manager {
+func NewManager(
+	wantListStorage WantListStorage,
+	blobStorage BlobStorage,
+	downloader Downloader,
+	logger logging.Logger,
+) *Manager {
 	return &Manager{
-		storage:           storage,
-		downloader:        downloader,
-		connectionStreams: newConnectionStreams(),
-		logger:            logger.New("replication_manager"),
+		wantListStorage: wantListStorage,
+		blobStorage:     blobStorage,
+		downloader:      downloader,
+		processes:       make(map[rpc.ConnectionId]*WantsProcess),
+		logger:          logger.New("replication_manager"),
 	}
 }
 
-func (r *Manager) HandleIncomingCreateWantsRequest(ctx context.Context) (<-chan messages.BlobWithSizeOrWantDistance, error) {
+func (m *Manager) HandleIncomingCreateWantsRequest(ctx context.Context) (<-chan messages.BlobWithSizeOrWantDistance, error) {
 	connectionId, ok := rpc.GetConnectionIdFromContext(ctx)
 	if !ok {
 		return nil, errors.New("connection id not found in context")
 	}
-	r.logger.WithField("connectionId", connectionId).Debug("incoming create wants")
+
+	m.lock.Lock()
+	defer m.lock.Unlock()
 
 	ch := make(chan messages.BlobWithSizeOrWantDistance)
-	r.connectionStreams.AddIncoming(connectionId, newIncomingStream(ctx, ch))
-	go r.sendWantListPeriodically(ctx, ch)
+	m.getOrCreateProcess(connectionId).AddIncoming(NewIncomingStream(ctx, ch))
 	return ch, nil
 }
 
-func (r *Manager) HandleOutgoingCreateWantsRequest(ctx context.Context, ch <-chan messages.BlobWithSizeOrWantDistance, peer transport.Peer) error {
+func (m *Manager) HandleOutgoingCreateWantsRequest(ctx context.Context, ch <-chan messages.BlobWithSizeOrWantDistance, peer transport.Peer) error {
 	connectionId, ok := rpc.GetConnectionIdFromContext(ctx)
 	if !ok {
 		return errors.New("connection id not found in context")
 	}
-	r.logger.WithField("connectionId", connectionId).Debug("outgoing create wants")
 
-	go r.handleOutgoing(ctx, connectionId, ch, peer)
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.getOrCreateProcess(connectionId).AddOutgoing(ctx, ch, peer)
 	return nil
 }
 
-func (r *Manager) handleOutgoing(ctx context.Context, id rpc.ConnectionId, ch <-chan messages.BlobWithSizeOrWantDistance, peer transport.Peer) {
-	for blobWithSizeOrWantDistance := range ch {
-		logger := r.logger.WithField("connection_id", id).WithField("blob", blobWithSizeOrWantDistance.Id().String())
-
-		if size, ok := blobWithSizeOrWantDistance.SizeOrWantDistance().Size(); ok {
-			logger.WithField("size", size.InBytes()).Debug("got size")
-			go r.downloader.OnHasReceived(ctx, peer, blobWithSizeOrWantDistance.Id(), size)
-			continue
-		}
-
-		if distance, ok := blobWithSizeOrWantDistance.SizeOrWantDistance().WantDistance(); ok {
-			// peer wants a blob
-			// todo tell it that we have it if we have it
-			logger.WithField("distance", distance.Int()).Debug("got distance")
-			continue
-		}
-
-		panic("logic error")
-	}
-
-	// todo channel closed
-}
-
-func (r *Manager) sendWantListPeriodically(ctx context.Context, ch chan<- messages.BlobWithSizeOrWantDistance) {
-	defer close(ch)
-	defer r.logger.Debug("terminating sending want list")
-
-	for {
-		wl, err := r.storage.GetWantList()
-		if err != nil {
-			r.logger.WithError(err).Error("could not get the want list")
-			continue
-		}
-
-		for _, v := range wl.List() {
-			v, err := messages.NewBlobWithWantDistance(v.Id, v.Distance)
-			if err != nil {
-				r.logger.WithError(err).Error("could not create a blob with want distance")
-				continue
-			}
-
-			r.logger.WithField("blob", v.Id()).Debug("sending wants")
-
-			select {
-			case ch <- v:
-				continue
-			case <-ctx.Done():
-				return
-			}
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(10 * time.Second): // todo change
-			continue
-		}
-	}
-}
-
-type connectionStreams struct {
-	m    map[rpc.ConnectionId]*streams
-	lock sync.Mutex
-}
-
-func newConnectionStreams() *connectionStreams {
-	return &connectionStreams{
-		m: make(map[rpc.ConnectionId]*streams),
-	}
-}
-
-func (cs *connectionStreams) AddIncoming(id rpc.ConnectionId, stream incomingStream) {
-	cs.lock.Lock()
-	defer cs.lock.Unlock()
-
-	streams, ok := cs.m[id]
+func (m *Manager) getOrCreateProcess(id rpc.ConnectionId) *WantsProcess {
+	v, ok := m.processes[id]
 	if !ok {
-		streams = newStreams()
-		cs.m[id] = streams
+		v = NewWantsProcess(
+			m.wantListStorage,
+			m.blobStorage,
+			m.downloader,
+			m.logger.WithField("connection_id", id),
+		)
+		m.processes[id] = v
 	}
-
-	streams.AddIncoming(stream)
-}
-
-type streams struct {
-	lock     sync.Mutex
-	incoming []incomingStream
-}
-
-func newStreams() *streams {
-	return &streams{}
-}
-
-func (s *streams) AddIncoming(stream incomingStream) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	s.incoming = append(s.incoming, stream)
-}
-
-type incomingStream struct {
-	ctx context.Context
-	ch  <-chan messages.BlobWithSizeOrWantDistance
-}
-
-func newIncomingStream(ctx context.Context, ch <-chan messages.BlobWithSizeOrWantDistance) incomingStream {
-	return incomingStream{ctx: ctx, ch: ch}
+	return v
 }

--- a/service/domain/blobs/replication/manager.go
+++ b/service/domain/blobs/replication/manager.go
@@ -13,7 +13,7 @@ import (
 
 type Manager struct {
 	wantListStorage WantListStorage
-	blobStorage     BlobStorage
+	blobStorage     BlobSizeRepository
 	downloader      Downloader
 	logger          logging.Logger
 
@@ -23,7 +23,7 @@ type Manager struct {
 
 func NewManager(
 	wantListStorage WantListStorage,
-	blobStorage BlobStorage,
+	blobStorage BlobSizeRepository,
 	downloader Downloader,
 	logger logging.Logger,
 ) *Manager {
@@ -46,7 +46,7 @@ func (m *Manager) HandleIncomingCreateWantsRequest(ctx context.Context) (<-chan 
 	defer m.lock.Unlock()
 
 	ch := make(chan messages.BlobWithSizeOrWantDistance)
-	m.getOrCreateProcess(connectionId).AddIncoming(NewIncomingStream(ctx, ch))
+	m.getOrCreateProcess(connectionId).AddIncoming(ctx, ch)
 	return ch, nil
 }
 

--- a/service/domain/blobs/replication/manager_test.go
+++ b/service/domain/blobs/replication/manager_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/planetary-social/go-ssb/fixtures"
 	"github.com/planetary-social/go-ssb/logging"
+	"github.com/planetary-social/go-ssb/service/adapters/mocks"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/blobs/replication"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
@@ -90,11 +91,13 @@ type testManager struct {
 
 func newTestManager(t *testing.T) testManager {
 	wantListStorage := newWantListStorageMock()
+	blobStorage := mocks.NewBlobStorageMock()
 	downloader := newDownloaderMock()
 	logger := logging.NewDevNullLogger()
 
 	manager := replication.NewManager(
 		wantListStorage,
+		blobStorage,
 		downloader,
 		logger,
 	)

--- a/service/domain/blobs/replication/wants.go
+++ b/service/domain/blobs/replication/wants.go
@@ -1,0 +1,160 @@
+package replication
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/boreq/errors"
+	"github.com/planetary-social/go-ssb/logging"
+	"github.com/planetary-social/go-ssb/service/domain/messages"
+	"github.com/planetary-social/go-ssb/service/domain/refs"
+	"github.com/planetary-social/go-ssb/service/domain/transport"
+)
+
+type WantsProcess struct {
+	lock     sync.Mutex
+	incoming []IncomingStream
+
+	wantListStorage WantListStorage
+	blobStorage     BlobStorage
+	downloader      Downloader
+	logger          logging.Logger
+}
+
+func NewWantsProcess(
+	wantListStorage WantListStorage,
+	blobStorage BlobStorage,
+	downloader Downloader,
+	logger logging.Logger,
+) *WantsProcess {
+	return &WantsProcess{
+		wantListStorage: wantListStorage,
+		blobStorage:     blobStorage,
+		downloader:      downloader,
+		logger:          logger.New("wants_process"),
+	}
+}
+
+func (p *WantsProcess) AddIncoming(stream IncomingStream) {
+	p.logger.Debug("adding incoming")
+
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.incoming = append(p.incoming, stream)
+	go p.incomingLoop(stream)
+}
+
+func (p *WantsProcess) AddOutgoing(ctx context.Context, ch <-chan messages.BlobWithSizeOrWantDistance, peer transport.Peer) {
+	p.logger.Debug("adding outgoing")
+	go p.outgoingLoop(ctx, ch, peer)
+}
+
+func (p *WantsProcess) incomingLoop(stream IncomingStream) {
+	defer close(stream.ch)
+	// todo cleanup?
+
+	for {
+		wl, err := p.wantListStorage.GetWantList()
+		if err != nil {
+			p.logger.WithError(err).Error("could not get the want list")
+			continue
+		}
+
+		for _, v := range wl.List() {
+			v, err := messages.NewBlobWithWantDistance(v.Id, v.Distance)
+			if err != nil {
+				p.logger.WithError(err).Error("could not create a blob with want distance")
+				continue
+			}
+
+			p.logger.WithField("blob", v.Id()).Debug("sending wants")
+
+			select {
+			case stream.ch <- v:
+				continue
+			case <-stream.ctx.Done():
+				return
+			}
+		}
+
+		select {
+		case <-stream.ctx.Done():
+			return
+		case <-time.After(10 * time.Second): // todo change
+			continue
+		}
+	}
+}
+
+func (p *WantsProcess) outgoingLoop(ctx context.Context, ch <-chan messages.BlobWithSizeOrWantDistance, peer transport.Peer) {
+	for hasOrWant := range ch {
+		logger := p.logger.WithField("blob", hasOrWant.Id().String())
+
+		if size, ok := hasOrWant.SizeOrWantDistance().Size(); ok {
+			logger.WithField("size", size.InBytes()).Debug("received has")
+			go p.downloader.OnHasReceived(ctx, peer, hasOrWant.Id(), size)
+			continue
+		}
+
+		if distance, ok := hasOrWant.SizeOrWantDistance().WantDistance(); ok {
+			logger.WithField("distance", distance.Int()).Debug("received want")
+
+			if err := p.onReceiveWant(hasOrWant.Id()); err != nil {
+				logger.WithError(err).Error("error processing a want")
+			}
+
+			continue
+		}
+
+		panic("logic error")
+	}
+
+	// todo channel closed, cleanup?
+}
+
+func (p *WantsProcess) onReceiveWant(id refs.Blob) error {
+	size, err := p.blobStorage.Size(id)
+	if err != nil {
+		if errors.Is(err, ErrBlobNotFound) {
+			p.logger.WithField("blob", id).Debug("we don't have this blob")
+			return nil
+		}
+		return errors.Wrap(err, "could not get blob size")
+	}
+
+	has, err := messages.NewBlobWithSize(id, size)
+	if err != nil {
+		return errors.Wrap(err, "could not create a has")
+	}
+
+	p.sendToAll(has)
+	return nil
+}
+
+func (p *WantsProcess) sendToAll(wantOrHas messages.BlobWithSizeOrWantDistance) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.logger.
+		WithField("v", wantOrHas).
+		WithField("num_incoming", len(p.incoming)).
+		Debug("sending want or has")
+
+	for _, incoming := range p.incoming {
+		incoming.ch <- wantOrHas // todo what if this is slow
+	}
+}
+
+type IncomingStream struct {
+	ctx context.Context
+	ch  chan<- messages.BlobWithSizeOrWantDistance
+}
+
+func NewIncomingStream(ctx context.Context, ch chan<- messages.BlobWithSizeOrWantDistance) IncomingStream {
+	return IncomingStream{
+		ctx: ctx,
+		ch:  ch,
+	}
+}

--- a/service/domain/blobs/replication/wants.go
+++ b/service/domain/blobs/replication/wants.go
@@ -7,17 +7,10 @@ import (
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/logging"
-	"github.com/planetary-social/go-ssb/service/domain/blobs"
 	"github.com/planetary-social/go-ssb/service/domain/messages"
 	"github.com/planetary-social/go-ssb/service/domain/refs"
 	"github.com/planetary-social/go-ssb/service/domain/transport"
 )
-
-type BlobSizeRepository interface {
-	// Size returns the size of the blob. If the blob is not found it returns
-	// ErrBlobNotFound.
-	Size(id refs.Blob) (blobs.Size, error)
-}
 
 type WantsProcess struct {
 	incomingLock sync.Mutex

--- a/service/domain/blobs/replication/wants_test.go
+++ b/service/domain/blobs/replication/wants_test.go
@@ -1,0 +1,111 @@
+package replication_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/planetary-social/go-ssb/fixtures"
+	"github.com/planetary-social/go-ssb/logging"
+	"github.com/planetary-social/go-ssb/service/adapters/mocks"
+	"github.com/planetary-social/go-ssb/service/domain/blobs"
+	"github.com/planetary-social/go-ssb/service/domain/blobs/replication"
+	"github.com/planetary-social/go-ssb/service/domain/messages"
+	"github.com/planetary-social/go-ssb/service/domain/transport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepliesToWantsWithHas(t *testing.T) {
+	p := newTestWantsProcess()
+
+	ctx := fixtures.TestContext(t)
+	outgoingCh := make(chan messages.BlobWithSizeOrWantDistance)
+	peer := transport.NewPeer(fixtures.SomePublicIdentity(), nil)
+	p.WantsProcess.AddOutgoing(ctx, outgoingCh, peer)
+
+	incomingCh := make(chan messages.BlobWithSizeOrWantDistance)
+	p.WantsProcess.AddIncoming(ctx, incomingCh)
+
+	blobId := fixtures.SomeRefBlob()
+	p.BlobStorage.MockBlob(blobId, fixtures.SomeBytes())
+
+	go func() {
+		select {
+		case outgoingCh <- messages.MustNewBlobWithWantDistance(blobId, blobs.NewWantDistanceLocal()):
+			return
+		case <-ctx.Done():
+			t.Fatal("context done")
+		}
+	}()
+
+	select {
+	case sent := <-incomingCh:
+		require.Equal(t, blobId, sent.Id())
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestPassesHasToDownloader(t *testing.T) {
+	p := newTestWantsProcess()
+
+	ctx, cancel := context.WithTimeout(fixtures.TestContext(t), 5*time.Second)
+	defer cancel()
+
+	outgoingCh := make(chan messages.BlobWithSizeOrWantDistance)
+	peer := transport.NewPeer(fixtures.SomePublicIdentity(), nil)
+	p.WantsProcess.AddOutgoing(ctx, outgoingCh, peer)
+
+	blobId := fixtures.SomeRefBlob()
+	blobSize := fixtures.SomeSize()
+
+	select {
+	case outgoingCh <- messages.MustNewBlobWithSize(blobId, blobSize):
+	case <-ctx.Done():
+		t.Fatal("context done")
+	}
+
+	require.Eventually(t,
+		func() bool {
+			return assert.ObjectsAreEqual(
+				[]onHasReceivedCall{
+					{
+						Peer: peer,
+						Blob: blobId,
+						Size: blobSize,
+					},
+				},
+				p.Downloader.OnHasReceivedCalls(),
+			)
+		},
+		1*time.Second,
+		10*time.Millisecond,
+	)
+}
+
+type TestWantsProcess struct {
+	WantsProcess *replication.WantsProcess
+	BlobStorage  *mocks.BlobStorageMock
+	Downloader   *downloaderMock
+}
+
+func newTestWantsProcess() TestWantsProcess {
+	wantListStorage := newWantListStorageMock()
+	downloader := newDownloaderMock()
+	blobStorage := mocks.NewBlobStorageMock()
+	logger := logging.NewDevNullLogger()
+
+	process := replication.NewWantsProcess(
+		wantListStorage,
+		blobStorage,
+		downloader,
+		logger,
+	)
+
+	return TestWantsProcess{
+		WantsProcess: process,
+		BlobStorage:  blobStorage,
+		Downloader:   downloader,
+	}
+}

--- a/service/domain/blobs/replication/wants_test.go
+++ b/service/domain/blobs/replication/wants_test.go
@@ -35,7 +35,7 @@ func TestRepliesToWantsWithHas(t *testing.T) {
 		case outgoingCh <- messages.MustNewBlobWithWantDistance(blobId, blobs.NewWantDistanceLocal()):
 			return
 		case <-ctx.Done():
-			t.Fatal("context done")
+			panic("context done")
 		}
 	}()
 

--- a/service/domain/messages/blobs_createWants.go
+++ b/service/domain/messages/blobs_createWants.go
@@ -2,6 +2,8 @@ package messages
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/boreq/errors"
 	"github.com/planetary-social/go-ssb/service/domain/blobs"
@@ -144,4 +146,16 @@ func (b BlobWithSizeOrWantDistance) Id() refs.Blob {
 
 func (b BlobWithSizeOrWantDistance) SizeOrWantDistance() blobs.SizeOrWantDistance {
 	return b.sizeOrWantDistance
+}
+
+func (b BlobWithSizeOrWantDistance) String() string {
+	var s []string
+	s = append(s, fmt.Sprintf("id=%s", b.id.String()))
+	if distance, ok := b.sizeOrWantDistance.WantDistance(); ok {
+		s = append(s, fmt.Sprintf("distance=%d", distance.Int()))
+	}
+	if size, ok := b.sizeOrWantDistance.Size(); ok {
+		s = append(s, fmt.Sprintf("size=%d", size.InBytes()))
+	}
+	return fmt.Sprintf("<%s>", strings.Join(s, " "))
 }

--- a/service/domain/messages/blobs_createWants.go
+++ b/service/domain/messages/blobs_createWants.go
@@ -131,6 +131,14 @@ func NewBlobWithWantDistance(id refs.Blob, wantDistance blobs.WantDistance) (Blo
 	return NewBlobWithSizeOrWantDistance(id, v)
 }
 
+func MustNewBlobWithWantDistance(id refs.Blob, wantDistance blobs.WantDistance) BlobWithSizeOrWantDistance {
+	v, err := NewBlobWithWantDistance(id, wantDistance)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 func NewBlobWithSize(id refs.Blob, size blobs.Size) (BlobWithSizeOrWantDistance, error) {
 	v, err := blobs.NewSizeOrWantDistanceContainingSize(size)
 	if err != nil {
@@ -138,6 +146,14 @@ func NewBlobWithSize(id refs.Blob, size blobs.Size) (BlobWithSizeOrWantDistance,
 	}
 
 	return NewBlobWithSizeOrWantDistance(id, v)
+}
+
+func MustNewBlobWithSize(id refs.Blob, size blobs.Size) BlobWithSizeOrWantDistance {
+	v, err := NewBlobWithSize(id, size)
+	if err != nil {
+		panic(err)
+	}
+	return v
 }
 
 func (b BlobWithSizeOrWantDistance) Id() refs.Blob {


### PR DESCRIPTION
This implements replying to "wants" messages with "has" messages. "Wants" messages are received through `blobs.createWants` stream initiated by the local node and have to trigger a reply with a "has" message through `blobs.createWants` stream initiated by the remote node.